### PR TITLE
Fix state_size property

### DIFF
--- a/SRU_tensorflow.py
+++ b/SRU_tensorflow.py
@@ -24,7 +24,7 @@ class SRUCell(RNNCell):
     @property
     def state_size(self):
         return (LSTMStateTuple(self.hidden_dim, self.hidden_dim)
-                if self.state_is_tuple else 2 * self.hidden_dim)
+                if self.state_is_tuple else self.hidden_dim)
 
     @property
     def output_size(self):

--- a/SRU_tensorflow.py
+++ b/SRU_tensorflow.py
@@ -23,7 +23,8 @@ class SRUCell(RNNCell):
 
     @property
     def state_size(self):
-        return self.hidden_dim
+        return (LSTMStateTuple(self.hidden_dim, self.hidden_dim)
+                if self.state_is_tuple else 2 * self.hidden_dim)
 
     @property
     def output_size(self):


### PR DESCRIPTION
When `state_is_tuple` is true, `state_size` should return an `LSTMStateTuple`.